### PR TITLE
Handle missing directories

### DIFF
--- a/src/main/scala/com/coxautodata/OptionsParsing.scala
+++ b/src/main/scala/com/coxautodata/OptionsParsing.scala
@@ -1,7 +1,9 @@
 package com.coxautodata
 
-import java.net.URI
+import com.coxautodata.utils.DirectoryUtils.missingDirectoryAction
+import com.coxautodata.utils.{DirectoryUtils, MissingDirectoryAction}
 
+import java.net.URI
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
@@ -63,6 +65,10 @@ object OptionsParsing {
       opt[Long]("maxBytesPerTask")
         .action((i, c) => c.copyOptions(_.copy(maxBytesPerTask = i)))
         .text("Maximum number of bytes to copy in a single Spark task")
+
+      opt[String]("onMissingDirectory")
+        .action((s, c) => c.copyOptions(_.copy(missingDirectoryAction = missingDirectoryAction(s))))
+        .text("Behaviour when source or target does not exist: either fail (default), create or log")
 
       help("help").text("prints this usage text")
 

--- a/src/main/scala/com/coxautodata/SparkDistCP.scala
+++ b/src/main/scala/com/coxautodata/SparkDistCP.scala
@@ -95,7 +95,8 @@ object SparkDistCP extends Logging {
       qualifiedDestinationPath.toUri,
       options.updateOverwritePathBehaviour,
       options.numListstatusThreads,
-      options.filterNot
+      options.filterNot,
+      options.missingDirectoryAction
     )
     val destinationRDD = FileListUtils.getDestinationFiles(
       sparkSession.sparkContext,

--- a/src/main/scala/com/coxautodata/SparkDistCPOptions.scala
+++ b/src/main/scala/com/coxautodata/SparkDistCPOptions.scala
@@ -1,5 +1,6 @@
 package com.coxautodata
 
+import com.coxautodata.utils.{FailMissingDirectoryAction, MissingDirectoryAction}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
@@ -24,7 +25,8 @@ case class SparkDistCPOptions(
   filters: Option[URI] = SparkDistCPOptions.Defaults.filters,
   filterNot: List[Regex] = SparkDistCPOptions.Defaults.filterNot,
   numListstatusThreads: Int = SparkDistCPOptions.Defaults.numListstatusThreads,
-  verbose: Boolean = SparkDistCPOptions.Defaults.verbose
+  verbose: Boolean = SparkDistCPOptions.Defaults.verbose,
+  missingDirectoryAction: MissingDirectoryAction = SparkDistCPOptions.Defaults.missingDirectoryAction
 ) {
 
   val updateOverwritePathBehaviour: Boolean =
@@ -93,6 +95,7 @@ object SparkDistCPOptions {
     val filterNot: List[Regex] = List.empty
     val numListstatusThreads: Int = 10
     val verbose: Boolean = false
+    val missingDirectoryAction : MissingDirectoryAction = FailMissingDirectoryAction
   }
 
 }

--- a/src/main/scala/com/coxautodata/objects/Accumulators.scala
+++ b/src/main/scala/com/coxautodata/objects/Accumulators.scala
@@ -91,7 +91,7 @@ class Accumulators(sparkSession: SparkSession) extends Serializable {
       exceptionCount.value.asScala.toSeq
         .sortWith { case ((_, v1), (_, v2)) => v1 > v2 }
         .map { case (k, v) => s"$k: ${intFormatter.format(v)}" }
-        .mkString("\n")
+        .mkString(System.getProperty("line.separator"))
   }
 
   val bytesCopied: LongAccumulator =

--- a/src/main/scala/com/coxautodata/utils/DirectoryUtils.scala
+++ b/src/main/scala/com/coxautodata/utils/DirectoryUtils.scala
@@ -1,0 +1,77 @@
+package com.coxautodata.utils
+
+import com.coxautodata.objects.Logging
+import com.coxautodata.utils.DirectoryUtils.NO_FILES
+import org.apache.hadoop.fs.{FileSystem, LocatedFileStatus, Path, RemoteIterator}
+
+import java.io.FileNotFoundException
+
+abstract sealed class MissingDirectoryAction extends Logging {
+  def requireDirectory(destFS: FileSystem, destPath: Path): Unit
+
+  def createDirectory(destFS: FileSystem, destPath: Path): Unit = destFS.mkdirs(destPath)
+
+  def listFiles(destFS: FileSystem, destPath: Path): RemoteIterator[LocatedFileStatus] = {
+    if (destFS.exists(destPath)) {
+      destFS.listLocatedStatus(destPath)
+    } else {
+      logWarning(s"Folder [${destPath.getParent}] does not exist.")
+      NO_FILES
+    }
+  }
+
+}
+
+case object CreateMissingDirectoryAction extends MissingDirectoryAction {
+  override def requireDirectory(destFS: FileSystem, destPath: Path): Unit = {
+    if (!destFS.exists(destPath)) {
+      destFS.mkdirs(destPath)
+    }
+  }
+}
+
+case object FailMissingDirectoryAction extends MissingDirectoryAction {
+  override def requireDirectory(destFS: FileSystem, destPath: Path): Unit = {
+    if (!destFS.exists(destPath)) {
+      throw new FileNotFoundException(s"Folder [${destPath}] does not exist.")
+    }
+  }
+
+  override def listFiles(destFS: FileSystem, destPath: Path): RemoteIterator[LocatedFileStatus] = {
+    if (destFS.exists(destPath)) {
+      destFS.listLocatedStatus(destPath)
+    } else {
+      throw new FileNotFoundException(s"Folder [${destPath}] does not exist.")
+    }
+  }
+}
+
+case object LogMissingDirectoryAction extends MissingDirectoryAction {
+  override def requireDirectory(destFS: FileSystem, destPath: Path): Unit = {
+    if (!destFS.exists(destPath)) {
+      logWarning(s"Folder [${destPath.getParent}] does not exist.")
+    }
+  }
+
+  override def createDirectory(destFS: FileSystem, destPath: Path): Unit = {
+    logDebug(s"Do not create folder [${destPath}].")
+  }
+}
+
+private class EmptyRemoteIterator[E] extends RemoteIterator[E] {
+  override def hasNext: Boolean = false
+
+  override def next(): E = throw new UnsupportedOperationException()
+}
+
+object DirectoryUtils {
+  val NO_FILES: RemoteIterator[LocatedFileStatus] = new EmptyRemoteIterator[LocatedFileStatus]()
+
+  def missingDirectoryAction(name: String): MissingDirectoryAction = name.trim.toLowerCase match {
+    case "create" => CreateMissingDirectoryAction
+    case "log" => LogMissingDirectoryAction
+    case "fail" => FailMissingDirectoryAction
+    case _ => throw new IllegalArgumentException(s"Invalid missing directory option [$name]")
+  }
+
+}

--- a/src/test/scala/com/coxautodata/utils/TestCopyUtils.scala
+++ b/src/test/scala/com/coxautodata/utils/TestCopyUtils.scala
@@ -50,7 +50,7 @@ class TestCopyUtils extends TestSpec {
         localFileSystem,
         destPath.toUri,
         removeExisting = false,
-        ignoreErrors = false,
+        SparkDistCPOptions(),
         taskAttemptID = 1
       )
 
@@ -83,7 +83,7 @@ class TestCopyUtils extends TestSpec {
         localFileSystem,
         destPath.toUri,
         removeExisting = true,
-        ignoreErrors = false,
+        SparkDistCPOptions(),
         taskAttemptID = 1
       )
 
@@ -109,7 +109,7 @@ class TestCopyUtils extends TestSpec {
           localFileSystem,
           destPath.toUri,
           removeExisting = false,
-          ignoreErrors = false,
+          new SparkDistCPOptions(),
           taskAttemptID = 1
         )
       }
@@ -120,7 +120,7 @@ class TestCopyUtils extends TestSpec {
         localFileSystem,
         destPath.toUri,
         removeExisting = false,
-        ignoreErrors = true,
+        SparkDistCPOptions(ignoreErrors=true),
         taskAttemptID = 2
       ).getMessage should be(
         s"Source: [${source.getPath.toUri}], Destination: [$destPath], " +
@@ -355,7 +355,7 @@ class TestCopyUtils extends TestSpec {
       ).getMessage should be(
         s"Source: [${source.getPath.toUri}], " +
           s"Destination: [$destPath], Type: [FileCopy: 1 bytes], " +
-          s"Result: [Failed: Destination folder [${destPath.getParent}] does not exist]"
+          s"Result: [Failed: Folder [${destPath.getParent}] does not exist.]"
       )
 
     }

--- a/src/test/scala/com/coxautodata/utils/TestFileListUtils.scala
+++ b/src/test/scala/com/coxautodata/utils/TestFileListUtils.scala
@@ -16,7 +16,8 @@ class TestFileListUtils extends TestSpec {
           new Path(testingBaseDirPath, "src"),
           10,
           false,
-          List.empty
+          List.empty,
+          FailMissingDirectoryAction
         )
       }
     }
@@ -28,7 +29,8 @@ class TestFileListUtils extends TestSpec {
         new Path(testingBaseDirPath, "src"),
         10,
         false,
-        List.empty
+        List.empty,
+        FailMissingDirectoryAction
       ) should contain theSameElementsAs Seq.empty
     }
 
@@ -39,7 +41,8 @@ class TestFileListUtils extends TestSpec {
         new Path(testingBaseDirPath, "src"),
         10,
         true,
-        List.empty
+        List.empty,
+        FailMissingDirectoryAction
       )
         .map(f =>
           (fileStatusToResult(f._1), f._2.map(fileStatusToResult))
@@ -59,7 +62,8 @@ class TestFileListUtils extends TestSpec {
         new Path(testingBaseDirPath, "src"),
         10,
         true,
-        List.empty
+        List.empty,
+        FailMissingDirectoryAction
       )
         .map(f =>
           (fileStatusToResult(f._1), f._2.map(fileStatusToResult))
@@ -100,7 +104,8 @@ class TestFileListUtils extends TestSpec {
         new Path(testingBaseDirPath, "src"),
         10,
         false,
-        List.empty
+        List.empty,
+        FailMissingDirectoryAction
       )
         .map(f =>
           (fileStatusToResult(f._1), f._2.map(fileStatusToResult))
@@ -239,7 +244,8 @@ class TestFileListUtils extends TestSpec {
         new Path(testingBaseDirPath, "src"),
         10,
         false,
-        List(""".*/1\.file$""".r, """.*/3\.file$""".r)
+        List(""".*/1\.file$""".r, """.*/3\.file$""".r),
+        FailMissingDirectoryAction
       )
         .map(f =>
           (fileStatusToResult(f._1), f._2.map(fileStatusToResult))
@@ -311,7 +317,8 @@ class TestFileListUtils extends TestSpec {
         new Path(testingBaseDirPath, "src"),
         10,
         false,
-        List(""".*/subsub1($|/.*)""".r)
+        List(""".*/subsub1($|/.*)""".r),
+        FailMissingDirectoryAction
       )
         .map(f =>
           (fileStatusToResult(f._1), f._2.map(fileStatusToResult))
@@ -426,7 +433,8 @@ class TestFileListUtils extends TestSpec {
           new Path(testingBaseDirPath, "target").toUri,
           true,
           2,
-          List.empty
+          List.empty,
+          FailMissingDirectoryAction
         )
       }.getMessage should be(
         "Collisions found where multiple source files lead to the same destination location; check executor logs for specific collision detail."
@@ -453,7 +461,8 @@ class TestFileListUtils extends TestSpec {
           new Path(testingBaseDirPath, "source").toUri,
           true,
           2,
-          List.empty
+          List.empty,
+          FailMissingDirectoryAction
         )
       }.getMessage should be(
         "Collisions found where a file has the same source and destination location; check executor logs for specific collision detail."


### PR DESCRIPTION
Trying to fix #10.

I introduced a configurable "missing directory" strategy:
* "fail" is default behaviour (HDFS)
* "create" auto creates target directory if not exist (HDFS)
* "log" doesn't fail nor create directories because it's not needed (S3, Ceph and other object storage)

Apologies for code quality, I am not fluent in Scala, tell me how to fix and improve.