### PR TITLE
Adapt log4j2 to support Spark 3.3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,9 @@ stages:
           Spark32013:
             SPARKVERSION: '3.2.0'
             SCALAVERSION: '2.13.8'
+          Spark3313:
+            SPARKVERSION: '3.3.4'
+            SCALAVERSION: '2.13.8'
         maxParallel: 10
       steps:
         - task: JavaToolInstaller@0

--- a/src/main/scala/com/coxautodata/SparkDistCP.scala
+++ b/src/main/scala/com/coxautodata/SparkDistCP.scala
@@ -5,7 +5,6 @@ import java.net.URI
 import com.coxautodata.objects._
 import com.coxautodata.utils.{CopyUtils, FileListUtils, PathUtils}
 import org.apache.hadoop.fs._
-import org.apache.log4j.Level
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{SaveMode, SparkSession}
 import org.apache.spark.{HashPartitioner, TaskContext}
@@ -77,7 +76,7 @@ object SparkDistCP extends Logging {
 
     if (options.verbose) {
       sparkSession.sparkContext.setLogLevel("DEBUG")
-      setLogLevel(Level.DEBUG)
+      setLogLevel("DEBUG")
     }
 
     val qualifiedSourcePaths = sourcePaths.map(

--- a/src/main/scala/com/coxautodata/objects/Logging.scala
+++ b/src/main/scala/com/coxautodata/objects/Logging.scala
@@ -1,6 +1,6 @@
 package com.coxautodata.objects
 
-import org.apache.log4j.{Level, LogManager, Logger}
+import org.slf4j.{Logger, LoggerFactory}
 
 trait Logging {
 
@@ -10,10 +10,33 @@ trait Logging {
     this.getClass.getName.stripSuffix("$")
   }
 
-  private val log: Logger = LogManager.getLogger(logName)
+  private[objects] val log: Logger = LoggerFactory.getLogger(logName)
 
   // Set logger level
-  protected def setLogLevel(level: Level): Unit = log.setLevel(level)
+  protected[objects] def setLogLevel(level: String): Unit = {
+    log.getClass.getName match {
+      case "org.slf4j.impl.Log4jLoggerAdapter" =>
+        val log4j1LevelClass = Class.forName("org.apache.log4j.Level")
+        val log4j1Level = log4j1LevelClass.getField(level).get(null)
+        val log4j1LoggerField = log.getClass.getDeclaredField("logger")
+        log4j1LoggerField.setAccessible(true)
+        val log4j1Logger = log4j1LoggerField.get(log)
+        val setLevelMethod = log4j1Logger.getClass.getMethod("setLevel", log4j1LevelClass)
+        setLevelMethod.invoke(log4j1Logger, log4j1Level)
+      case "org.apache.logging.slf4j.Log4jLogger" =>
+        val log4j2LevelClass = Class.forName("org.apache.logging.log4j.Level")
+        val log4j2Level = log4j2LevelClass.getField(level).get(null)
+        val log4j2LoggerField = log.getClass.getDeclaredField("logger")
+        log4j2LoggerField.setAccessible(true)
+        val log4j2Logger = log4j2LoggerField.get(log)
+        val setLevelMethod = log4j2Logger.getClass.getMethod("setLevel", log4j2LevelClass)
+        setLevelMethod.invoke(log4j2Logger, log4j2Level)
+      case unsupported =>
+        log.warn(
+          s"Unsupported logging framework: $unsupported, setLogLevel does nothing"
+        )
+    }
+  }
 
   // Log methods that take only a String
   protected def logInfo(msg: => String): Unit = {

--- a/src/main/scala/com/coxautodata/utils/CopyUtils.scala
+++ b/src/main/scala/com/coxautodata/utils/CopyUtils.scala
@@ -7,7 +7,6 @@ import com.coxautodata.SparkDistCPOptions
 import com.coxautodata.objects._
 import org.apache.hadoop.fs._
 import org.apache.hadoop.io.IOUtils
-import org.apache.log4j.Level
 
 import scala.util.{Failure, Success, Try}
 
@@ -34,7 +33,7 @@ object CopyUtils extends Logging {
     taskAttemptID: Long
   ): DistCPResult = {
 
-    if (options.verbose) setLogLevel(Level.DEBUG)
+    if (options.verbose) setLogLevel("DEBUG")
 
     val r = {
       if (definition.source.isDirectory) {
@@ -66,7 +65,7 @@ object CopyUtils extends Logging {
     options: SparkDistCPOptions
   ): DeleteResult = {
 
-    if (options.verbose) setLogLevel(Level.DEBUG)
+    if (options.verbose) setLogLevel("DEBUG")
 
     val path = new Path(uri)
 

--- a/src/test/scala/com/coxautodata/objects/TestChangeLoggerLevel.scala
+++ b/src/test/scala/com/coxautodata/objects/TestChangeLoggerLevel.scala
@@ -1,0 +1,17 @@
+package com.coxautodata.objects
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class TestChangeLoggerLevel extends AnyFunSpec with Matchers {
+
+  it("test implementation") {
+    val logging = new Object with Logging
+    logging.setLogLevel("DEBUG")
+    logging.log.isDebugEnabled should be(true)
+    logging.log.isInfoEnabled should be(true)
+    logging.setLogLevel("INFO")
+    logging.log.isDebugEnabled should be(false)
+    logging.log.isInfoEnabled should be(true)
+  }
+}


### PR DESCRIPTION
### Why changes are needed?
Since Spark 3.3, it migrate from Log4J 1.x to Log4J 2.x, see details in [SPARK-37814](https://issues.apache.org/jira/browse/SPARK-37814)

Currently, the `Logging` has a hard dependency on Log4J1, which does not work on Spark 3.3 and above.

### What are the changes?
This PR aims to use reflection to adapt both Log4J1 and Log4J2 to resolve such a compatible issue.

### How was it verified?
A new test case `TestChangeLoggerLevel` is added, also updated the Azure pipeline definition to include the Spark 3.3